### PR TITLE
Expose AWSClient APIOptions for middleware registration

### DIFF
--- a/internal/conns/awsclient_xp.go
+++ b/internal/conns/awsclient_xp.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package conns
+
+import "github.com/aws/smithy-go/middleware"
+
+func (c *AWSClient) AppendAPIOptions(options ...func(stack *middleware.Stack) error) {
+	c.awsConfig.APIOptions = append(c.awsConfig.APIOptions, options...)
+}

--- a/xpprovider/xpprovider.go
+++ b/xpprovider/xpprovider.go
@@ -22,7 +22,7 @@ import (
 type AWSConfig conns.Config
 
 // AWSClient exports the internal type conns.AWSClient of the Terraform provider
-type AWSClient conns.AWSClient
+type AWSClient = conns.AWSClient
 
 // GetProvider returns new provider instances for both Terraform Plugin Framework provider of type provider.Provider
 // and Terraform Plugin SDKv2 provider of type *schema.Provider


### PR DESCRIPTION
`conns.AWSClient` doesn't allow access to [its AWS SDK v2 client](https://github.com/upbound/terraform-provider-aws/blob/upjet-v5.31.0/internal/conns/awsclient.go#L39), which makes it impossible to register [middleware](https://aws.github.io/aws-sdk-go-v2/docs/middleware/) functions, to customize API calls. To enable such functionality, we add a public method that [appends middleware functions to `APIOptions`](https://aws.github.io/aws-sdk-go-v2/docs/middleware/#attaching-middleware-to-all-clients).

We replace `xpprovider.AWSClient` type definition with an [alias declaration](https://go.dev/ref/spec#Alias_declarations), so that exposed `APIOptions` method is directly accessible to importing code. Alias declaration also removes the need for unsafe pointer operations to convert between `xpprovider.AWSClient` and `conns.AWSClient`.

PS: `conns.AWSClient`'s [AWS SDK v1 `Session`](https://github.com/upbound/terraform-provider-aws/blob/upjet-v5.31.0/internal/conns/awsclient.go#L36) is public. Handlers, which are [predecessors of SDK v2 middlewares](https://aws.github.io/aws-sdk-go-v2/docs/migrating/#handler-phases), [can be registered to Sessions](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Adding_Handlers).