### PR TITLE
Expose AWS SDK Client Session

### DIFF
--- a/internal/conns/awsclient_xp.go
+++ b/internal/conns/awsclient_xp.go
@@ -3,8 +3,18 @@
 
 package conns
 
-import "github.com/aws/smithy-go/middleware"
+import (
+	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/smithy-go/middleware"
+)
 
+// AppendAPIOptions appends the specified AWS client APIOptions to
+// the client c.
 func (c *AWSClient) AppendAPIOptions(options ...func(stack *middleware.Stack) error) {
 	c.awsConfig.APIOptions = append(c.awsConfig.APIOptions, options...)
+}
+
+// Session returns the associated session with this client.
+func (c *AWSClient) Session() *session_sdkv1.Session {
+	return c.session
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As we are bumping the Terraform provider version to `v5.50.0`, we have observed that the AWS client session variable has been unexported and we use the session handlers to implement the API call counters in `crossplane-contrib/provider-upjet-aws`.  This PR exports the session variable via an `conns.AWSClient.Session` function.
