### PR TITLE
Add null check for lb_listener forward action config

### DIFF
--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -1036,7 +1036,7 @@ func flattenLbForwardActionOneOf(actions cty.Value, i int, awsAction awstypes.Ac
 			action := actions.Index(index)
 			if action.IsKnown() && !action.IsNull() {
 				forward := action.GetAttr("forward")
-				if forward.IsKnown() && forward.LengthInt() > 0 {
+				if forward.IsKnown() && !forward.IsNull() && forward.LengthInt() > 0 {
 					actionMap["forward"] = flattenLbListenerActionForwardConfig(awsAction.ForwardConfig)
 				} else {
 					actionMap["target_group_arn"] = aws.ToString(awsAction.TargetGroupArn)


### PR DESCRIPTION
LB Listener panics when the `default_action.0.forward` parameter is null. TF CLI sets this to an empty list, whereas upjet initializes this as a null list. During resource read, this causes the failure, as this value is being read from the RawConfig. 