### PR TITLE
Fix EC2 instance panic

### DIFF
--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -800,6 +800,10 @@ func GetAnyAttr(value cty.Value, attr string, shouldReturnSetElement func(string
 			return cty.NilVal, fmt.Errorf("invalid index: %s", indexStr)
 		}
 
+		if value.Type().IsListType() && (value.IsNull() || !value.IsKnown()) {
+			return cty.NilVal, fmt.Errorf("list attribute %s is unknown or null", attrName)
+		}
+
 		if index >= value.LengthInt() {
 			return cty.NilVal, fmt.Errorf("index %d out of range for attribute %s", index, attrName)
 		}


### PR DESCRIPTION
Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/1579.

### Cause

The panic originates from:
https://github.com/hashicorp/terraform-provider-aws/blob/v5.78.0/internal/service/ec2/ec2_instance.go#L2385

```go
if v, ok := d.GetOk("root_block_device"); ok && len(v.([]interface{})) > 0 && blockDeviceIsRoot(instanceBd, instance) {
	bd[names.AttrTags] = tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, "root_block_device[0].tags", nil).Map()
}
```

The code checks for existence of `root_block_device`, using `d.GetOk("root_block_device")`, before accessing its tags `root_block_device[0].tags`. The problem stems from the fact that Terraform has multiple sources of resource data which are combined as needed. These sources are: [state, config, diff, set](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.35.0/helper/schema/resource_data.go#L490-L495). When a piece of data exists in multiple sources, the one that comes later in the list is used.

Theoretically, `d.GetOk()` and `tags.ResolveDuplicates()` may read from different sources, which may cause different kinds of errors. In our case though, both read from `state`. Unfortunately, even the sources have “subsources”, from which a data can be read. For `state`, these “subsources” are [Attributes, RawConfig, RawState, RawPlan](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.35.0/terraform/state.go#L1287)

Whereas `d.GetOk()` [uses the multilevel reader](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.35.0/helper/schema/resource_data.go#L553) that [reads from `Attributes`](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.35.0/helper/schema/resource_data.go#L463-L467), `tags.ResolveDuplicates()` [reads from `RawConfig`](https://github.com/hashicorp/terraform-provider-aws/blob/v5.78.0/internal/tags/key_value_tags.go#L823).

To summarize, `d.GetOk("root_block_device")` returns `d.state.Attributes["root_block_device"]`, which exists. Then, `tags.ResolveDuplicates()` accesses `d.state.RawConfig.v["root_block_device"]`, which is nil.

### Fix

The panic [occurs at `cty.LengthInt()`](https://github.com/hashicorp/go-cty/blob/85980079f637862fa8e43ddc82dd74315e2f4c85/cty/value_ops.go#L989), which is [called from GetAnyAttr()](https://github.com/hashicorp/terraform-provider-aws/blob/v5.78.0/internal/tags/key_value_tags.go#L803). Note that, `LengthInt()` is called [only for list or tuple types](https://github.com/hashicorp/terraform-provider-aws/blob/v5.78.0/internal/tags/key_value_tags.go#L794-L796). [Nil tuples don't panic in `LengthInt()`](https://github.com/hashicorp/go-cty/blob/85980079f637862fa8e43ddc82dd74315e2f4c85/cty/value_ops.go#L977-L980). So, to prevent the panic, we only check whether the value is a non-nil and known list before calling `LengthInt()`.