### PR TITLE
Implement a public setter for client accountID

### DIFF
--- a/internal/conns/awsclient_xp.go
+++ b/internal/conns/awsclient_xp.go
@@ -18,3 +18,8 @@ func (c *AWSClient) AppendAPIOptions(options ...func(stack *middleware.Stack) er
 func (c *AWSClient) Session() *session_sdkv1.Session {
 	return c.session
 }
+
+// SetAccountID sets accountID of this client.
+func (c *AWSClient) SetAccountID(accountID string) {
+	c.accountID = accountID
+}


### PR DESCRIPTION
- Required in order to address changes introduced by: https://github.com/hashicorp/terraform-provider-aws/pull/40335/

- Specifically this commit in the PR linked above: https://github.com/hashicorp/terraform-provider-aws/commit/fa813c54d1645bda3135794c67ec34ee59deb3f4

- Given that accountID getter accepts a context parameter, which is currently unused, we may have to implement more substantial changes in future.

- I tested the implementation by consuming it in https://github.com/crossplane-contrib/provider-upjet-aws/pull/1629. I was able to provision a DynamoDB table and delete it.