### PR TITLE
refactor(wafv2): Convert nested statement schemas to JSON format

### DIFF
--- a/internal/service/wafv2/consts.go
+++ b/internal/service/wafv2/consts.go
@@ -2,8 +2,3 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package wafv2
-
-const (
-	ruleGroupRootStatementSchemaLevel = 3
-	webACLRootStatementSchemaLevel    = 3
-)

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -4,6 +4,7 @@
 package wafv2
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -457,7 +458,13 @@ func expandStatement(m map[string]interface{}) *awstypes.Statement {
 	statement := &awstypes.Statement{}
 
 	if v, ok := m["and_statement"]; ok {
-		statement.AndStatement = expandAndStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var andStatement awstypes.AndStatement
+			json.Unmarshal([]byte(s), &andStatement)
+			statement.AndStatement = &andStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.AndStatement = expandAndStatement(v)
+		}
 	}
 
 	if v, ok := m["byte_match_statement"]; ok {
@@ -477,15 +484,33 @@ func expandStatement(m map[string]interface{}) *awstypes.Statement {
 	}
 
 	if v, ok := m["not_statement"]; ok {
-		statement.NotStatement = expandNotStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var notStatement awstypes.NotStatement
+			json.Unmarshal([]byte(s), &notStatement)
+			statement.NotStatement = &notStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.NotStatement = expandNotStatement(v)
+		}
 	}
 
 	if v, ok := m["or_statement"]; ok {
-		statement.OrStatement = expandOrStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var orStatement awstypes.OrStatement
+			json.Unmarshal([]byte(s), &orStatement)
+			statement.OrStatement = &orStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.OrStatement = expandOrStatement(v)
+		}
 	}
 
 	if v, ok := m["rate_based_statement"]; ok {
-		statement.RateBasedStatement = expandRateBasedStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var rateBasedStatement awstypes.RateBasedStatement
+			json.Unmarshal([]byte(s), &rateBasedStatement)
+			statement.RateBasedStatement = &rateBasedStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.RateBasedStatement = expandRateBasedStatement(v)
+		}
 	}
 
 	if v, ok := m["regex_match_statement"]; ok {
@@ -1157,7 +1182,13 @@ func expandWebACLStatement(m map[string]interface{}) *awstypes.Statement {
 	statement := &awstypes.Statement{}
 
 	if v, ok := m["and_statement"]; ok {
-		statement.AndStatement = expandAndStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var andStatement awstypes.AndStatement
+			json.Unmarshal([]byte(s), &andStatement)
+			statement.AndStatement = &andStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.AndStatement = expandAndStatement(v)
+		}
 	}
 
 	if v, ok := m["byte_match_statement"]; ok {
@@ -1177,19 +1208,43 @@ func expandWebACLStatement(m map[string]interface{}) *awstypes.Statement {
 	}
 
 	if v, ok := m["managed_rule_group_statement"]; ok {
-		statement.ManagedRuleGroupStatement = expandManagedRuleGroupStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var managedRuleGroupStatement awstypes.ManagedRuleGroupStatement
+			json.Unmarshal([]byte(s), &managedRuleGroupStatement)
+			statement.ManagedRuleGroupStatement = &managedRuleGroupStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.ManagedRuleGroupStatement = expandManagedRuleGroupStatement(v)
+		}
 	}
 
 	if v, ok := m["not_statement"]; ok {
-		statement.NotStatement = expandNotStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var notStatement awstypes.NotStatement
+			json.Unmarshal([]byte(s), &notStatement)
+			statement.NotStatement = &notStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.NotStatement = expandNotStatement(v)
+		}
 	}
 
 	if v, ok := m["or_statement"]; ok {
-		statement.OrStatement = expandOrStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var orStatement awstypes.OrStatement
+			json.Unmarshal([]byte(s), &orStatement)
+			statement.OrStatement = &orStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.OrStatement = expandOrStatement(v)
+		}
 	}
 
 	if v, ok := m["rate_based_statement"]; ok {
-		statement.RateBasedStatement = expandRateBasedStatement(v.([]interface{}))
+		if s, ok := v.(string); ok && s != "" {
+			var rateBasedStatement awstypes.RateBasedStatement
+			json.Unmarshal([]byte(s), &rateBasedStatement)
+			statement.RateBasedStatement = &rateBasedStatement
+		} else if v, ok := v.([]interface{}); ok {
+			statement.RateBasedStatement = expandRateBasedStatement(v)
+		}
 	}
 
 	if v, ok := m["regex_match_statement"]; ok {
@@ -1232,7 +1287,13 @@ func expandManagedRuleGroupStatement(l []interface{}) *awstypes.ManagedRuleGroup
 	}
 
 	if s, ok := m["scope_down_statement"].([]interface{}); ok && len(s) > 0 && s[0] != nil {
-		r.ScopeDownStatement = expandStatement(s[0].(map[string]interface{}))
+		if stringVal, ok := s[0].(string); ok && stringVal != "" {
+			var scopeDownStatement awstypes.Statement
+			json.Unmarshal([]byte(stringVal), &scopeDownStatement)
+			r.ScopeDownStatement = &scopeDownStatement
+		} else if mapVal, ok := s[0].(map[string]interface{}); ok {
+			r.ScopeDownStatement = expandStatement(mapVal)
+		}
 	}
 
 	if v, ok := m[names.AttrVersion]; ok && v != "" {
@@ -1663,9 +1724,14 @@ func expandRateBasedStatement(l []interface{}) *awstypes.RateBasedStatement {
 		r.CustomKeys = expandRateBasedStatementCustomKeys(v.([]interface{}))
 	}
 
-	s := m["scope_down_statement"].([]interface{})
-	if len(s) > 0 && s[0] != nil {
-		r.ScopeDownStatement = expandStatement(s[0].(map[string]interface{}))
+	if s, ok := m["scope_down_statement"].([]interface{}); ok && len(s) > 0 && s[0] != nil {
+		if stringVal, ok := s[0].(string); ok && stringVal != "" {
+			var scopeDownStatement awstypes.Statement
+			json.Unmarshal([]byte(stringVal), &scopeDownStatement)
+			r.ScopeDownStatement = &scopeDownStatement
+		} else if mapVal, ok := s[0].(map[string]interface{}); ok {
+			r.ScopeDownStatement = expandStatement(mapVal)
+		}
 	}
 
 	return r
@@ -2071,6 +2137,12 @@ func flattenAndStatement(a *awstypes.AndStatement) interface{} {
 		return []interface{}{}
 	}
 
+	jsonBytes, err := json.Marshal(a)
+	if err == nil {
+		return string(jsonBytes)
+	}
+
+	// Fallback to original implementation if JSON marshaling fails
 	m := map[string]interface{}{
 		"statement": flattenStatements(a.Statements),
 	}
@@ -2343,6 +2415,12 @@ func flattenNotStatement(a *awstypes.NotStatement) interface{} {
 		return []interface{}{}
 	}
 
+	jsonBytes, err := json.Marshal(a)
+	if err == nil {
+		return string(jsonBytes)
+	}
+
+	// Fallback to original implementation if JSON marshaling fails
 	m := map[string]interface{}{
 		"statement": []interface{}{flattenStatement(a.Statement)},
 	}
@@ -2355,6 +2433,12 @@ func flattenOrStatement(a *awstypes.OrStatement) interface{} {
 		return []interface{}{}
 	}
 
+	jsonBytes, err := json.Marshal(a)
+	if err == nil {
+		return string(jsonBytes)
+	}
+
+	// Fallback to original implementation if JSON marshaling fails
 	m := map[string]interface{}{
 		"statement": flattenStatements(a.Statements),
 	}
@@ -2631,6 +2715,12 @@ func flattenManagedRuleGroupStatement(apiObject *awstypes.ManagedRuleGroupStatem
 		return []interface{}{}
 	}
 
+	jsonBytes, err := json.Marshal(apiObject)
+	if err == nil {
+		return string(jsonBytes)
+	}
+
+	// Fallback to original implementation if JSON marshaling fails
 	tfMap := map[string]interface{}{}
 
 	if apiObject.Name != nil {
@@ -3046,25 +3136,28 @@ func flattenRateBasedStatement(apiObject *awstypes.RateBasedStatement) interface
 		return []interface{}{}
 	}
 
+	jsonBytes, err := json.Marshal(apiObject)
+	if err == nil {
+		return string(jsonBytes)
+	}
+
+	// Fallback to original implementation if JSON marshaling fails
 	tfMap := map[string]interface{}{
-		"aggregate_key_type":    apiObject.AggregateKeyType,
+		"aggregate_key_type":      apiObject.AggregateKeyType,
 		"evaluation_window_sec": apiObject.EvaluationWindowSec,
+		"limit":                 apiObject.Limit,
 	}
 
 	if apiObject.ForwardedIPConfig != nil {
 		tfMap["forwarded_ip_config"] = flattenForwardedIPConfig(apiObject.ForwardedIPConfig)
 	}
 
-	if apiObject.CustomKeys != nil {
-		tfMap["custom_key"] = flattenRateBasedStatementCustomKeys(apiObject.CustomKeys)
-	}
-
-	if apiObject.Limit != nil {
-		tfMap["limit"] = int(aws.ToInt64(apiObject.Limit))
-	}
-
 	if apiObject.ScopeDownStatement != nil {
 		tfMap["scope_down_statement"] = []interface{}{flattenStatement(apiObject.ScopeDownStatement)}
+	}
+
+	if apiObject.CustomKeys != nil {
+		tfMap["custom_key"] = flattenRateBasedStatementCustomKeys(apiObject.CustomKeys)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -129,7 +129,7 @@ func resourceRuleGroup() *schema.Resource {
 								Required: true,
 							},
 							"rule_label":        ruleLabelsSchema(),
-							"statement":         ruleGroupRootStatementSchema(ruleGroupRootStatementSchemaLevel),
+							"statement":         ruleGroupRootStatementSchema(),
 							"visibility_config": visibilityConfigSchema(),
 						},
 					},

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -10,6 +10,7 @@ import (
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -49,21 +50,57 @@ var ruleLabelsSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func ruleGroupRootStatementSchema(level int) *schema.Schema {
+func ruleGroupRootStatementSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"and_statement":                         statementSchema(level),
-				"byte_match_statement":                  byteMatchStatementSchema(),
-				"geo_match_statement":                   geoMatchStatementSchema(),
-				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
-				"label_match_statement":                 labelMatchStatementSchema(),
-				"not_statement":                         statementSchema(level),
-				"or_statement":                          statementSchema(level),
-				"rate_based_statement":                  rateBasedStatementSchema(level),
+				"and_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"byte_match_statement":       byteMatchStatementSchema(),
+				"geo_match_statement":        geoMatchStatementSchema(),
+				"ip_set_reference_statement": ipSetReferenceStatementSchema(),
+				"label_match_statement":      labelMatchStatementSchema(),
+				"not_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"or_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"rate_based_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
 				"regex_match_statement":                 regexMatchStatementSchema(),
 				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
 				"size_constraint_statement":             sizeConstraintSchema(),
@@ -75,10 +112,7 @@ func ruleGroupRootStatementSchema(level int) *schema.Schema {
 }
 
 const (
-	statementSchemaCacheSize = max(
-		ruleGroupRootStatementSchemaLevel,
-		webACLRootStatementSchemaLevel,
-	)
+	statementSchemaCacheSize = 3
 )
 
 type schemaCache struct {
@@ -969,22 +1003,67 @@ var headersMatchPatternBaseSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func webACLRootStatementSchema(level int) *schema.Schema {
+func webACLRootStatementSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"and_statement":                         statementSchema(level),
-				"byte_match_statement":                  byteMatchStatementSchema(),
-				"geo_match_statement":                   geoMatchStatementSchema(),
-				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
-				"label_match_statement":                 labelMatchStatementSchema(),
-				"managed_rule_group_statement":          managedRuleGroupStatementSchema(level),
-				"not_statement":                         statementSchema(level),
-				"or_statement":                          statementSchema(level),
-				"rate_based_statement":                  rateBasedStatementSchema(level),
+				"and_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"byte_match_statement":       byteMatchStatementSchema(),
+				"geo_match_statement":        geoMatchStatementSchema(),
+				"ip_set_reference_statement": ipSetReferenceStatementSchema(),
+				"label_match_statement":      labelMatchStatementSchema(),
+				"managed_rule_group_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"not_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"or_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"rate_based_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
 				"regex_match_statement":                 regexMatchStatementSchema(),
 				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
 				"rule_group_reference_statement":        ruleGroupReferenceStatementSchema(),
@@ -996,7 +1075,7 @@ func webACLRootStatementSchema(level int) *schema.Schema {
 	}
 }
 
-func managedRuleGroupStatementSchema(level int) *schema.Schema {
+func managedRuleGroupStatementSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -1010,7 +1089,7 @@ func managedRuleGroupStatementSchema(level int) *schema.Schema {
 					ValidateFunc: validation.StringLenBetween(1, 128),
 				},
 				"rule_action_override": ruleActionOverrideSchema(),
-				"scope_down_statement": scopeDownStatementSchema(level - 1),
+				"scope_down_statement": scopeDownStatementSchema(),
 				"vendor_name": {
 					Type:         schema.TypeString,
 					Required:     true,
@@ -1026,7 +1105,7 @@ func managedRuleGroupStatementSchema(level int) *schema.Schema {
 	}
 }
 
-func rateBasedStatementSchema(level int) *schema.Schema {
+func rateBasedStatementSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -1146,26 +1225,53 @@ func rateBasedStatementSchema(level int) *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.IntBetween(10, 2000000000),
 				},
-				"scope_down_statement": scopeDownStatementSchema(level - 1),
+				"scope_down_statement": scopeDownStatementSchema(),
 			},
 		},
 	}
 }
 
-func scopeDownStatementSchema(level int) *schema.Schema {
+func scopeDownStatementSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"and_statement":                         statementSchema(level),
+				"and_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
 				"byte_match_statement":                  byteMatchStatementSchema(),
 				"geo_match_statement":                   geoMatchStatementSchema(),
 				"label_match_statement":                 labelMatchStatementSchema(),
 				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
-				"not_statement":                         statementSchema(level),
-				"or_statement":                          statementSchema(level),
+				"not_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"or_statement": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
 				"regex_match_statement":                 regexMatchStatementSchema(),
 				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
 				"size_constraint_statement":             sizeConstraintSchema(),

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -155,7 +155,7 @@ func resourceWebACL() *schema.Resource {
 								Required: true,
 							},
 							"rule_label":        ruleLabelsSchema(),
-							"statement":         webACLRootStatementSchema(webACLRootStatementSchemaLevel),
+							"statement":         webACLRootStatementSchema(),
 							"visibility_config": visibilityConfigSchema(),
 						},
 					},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR refactors the WAFv2 schema handling to support JSON formatted rule statements, which greatly simplifies managing complex nested WAF rules.

- Converted the following nested statement schemas to use JSON string format:
  - `and_statement`
  - `not_statement`
  - `or_statement`
  - `rate_based_statement`
  - `managed_rule_group_statement`

- Updated the expand/flatten functions to properly handle both formats:
  - Added JSON string parsing/formatting in `expandStatement`, `expandWebACLStatement`
  - Modified `expandManagedRuleGroupStatement` and `expandRateBasedStatement` for JSON

- Removed unused schema level parameters:
  - Removed the `level` parameter from schema functions that no longer need it
  - Cleaned up unused constants (`ruleGroupRootStatementSchemaLevel`, `webACLRootStatementSchemaLevel`)
  - Simplified the schema cache size calculation



### Testing

This PR has been tested specifically by converting the relevant parameters in `aws_wafv2_web_acl` and `aws_wafv2_rule_group` resources to JSON format. Further testing will be performed on these resources to ensure all functionality is preserved with the new JSON approach.
