### PR TITLE
feat(wafv2): add rule_json support to rule_group resource

### DIFF
--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -99,9 +100,21 @@ func resourceRuleGroup() *schema.Resource {
 						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]+$`), "must contain only alphanumeric hyphen and underscore characters"),
 					),
 				},
+				"rule_json": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ConflictsWith:    []string{names.AttrRule},
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v interface{}) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
 				names.AttrRule: {
-					Type:     schema.TypeSet,
-					Optional: true,
+					Type:          schema.TypeSet,
+					Optional:      true,
+					ConflictsWith: []string{"rule_json"},
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							names.AttrAction: {
@@ -158,10 +171,21 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 	input := &wafv2.CreateRuleGroupInput{
 		Capacity:         aws.Int64(int64(d.Get("capacity").(int))),
 		Name:             aws.String(name),
-		Rules:            expandRules(d.Get(names.AttrRule).(*schema.Set).List()),
 		Scope:            awstypes.Scope(d.Get(names.AttrScope).(string)),
 		Tags:             getTagsIn(ctx),
 		VisibilityConfig: expandVisibilityConfig(d.Get("visibility_config").([]interface{})),
+	}
+
+	if v, ok := d.GetOk(names.AttrRule); ok {
+		input.Rules = expandRules(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("rule_json"); ok {
+		rules, err := expandWebACLRulesJSON(v.(string))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+		}
+		input.Rules = rules
 	}
 
 	if v, ok := d.GetOk("custom_response_body"); ok && v.(*schema.Set).Len() > 0 {
@@ -215,9 +239,15 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("lock_token", output.LockToken)
 	d.Set(names.AttrName, ruleGroup.Name)
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(ruleGroup.Name)))
-	if err := d.Set(names.AttrRule, flattenRules(ruleGroup.Rules)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+
+	if _, ok := d.GetOk(names.AttrRule); ok {
+		if err := d.Set(names.AttrRule, flattenRules(ruleGroup.Rules)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+		}
 	}
+
+	d.Set("rule_json", d.Get("rule_json"))
+
 	if err := d.Set("visibility_config", flattenVisibilityConfig(ruleGroup.VisibilityConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting visibility_config: %s", err)
 	}
@@ -234,9 +264,20 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			Id:               aws.String(d.Id()),
 			LockToken:        aws.String(d.Get("lock_token").(string)),
 			Name:             aws.String(d.Get(names.AttrName).(string)),
-			Rules:            expandRules(d.Get(names.AttrRule).(*schema.Set).List()),
 			Scope:            awstypes.Scope(d.Get(names.AttrScope).(string)),
 			VisibilityConfig: expandVisibilityConfig(d.Get("visibility_config").([]interface{})),
+		}
+
+		if v, ok := d.GetOk(names.AttrRule); ok {
+			input.Rules = expandRules(v.(*schema.Set).List())
+		}
+
+		if v, ok := d.GetOk("rule_json"); ok {
+			rules, err := expandWebACLRulesJSON(v.(string))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+			}
+			input.Rules = rules
 		}
 
 		if v, ok := d.GetOk("custom_response_body"); ok && v.(*schema.Set).Len() > 0 {


### PR DESCRIPTION
### Description

This PR adds support for the `rule_json` parameter to the WAFv2 Rule Group resource, modeled after similar functionality in the Web ACL resource. This addition allows users to define Rule Group rules in a more flexible JSON format.

- Added `rule_json` field to Rule Group schema
- Utilized existing transformation functions (expandWebACLRulesJSON)
- Configured consistently with Web ACL implementation


### Test

This PR has been tested locally with the rule_json attribute in the rule group resource.

Tested both rule group and web acl with uptest:
- [Uptest-examples/wafv2/v1beta1/rulegroup.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/14752647341)
- [Uptest-examples/wafv2/v1beta1/webacl.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/14753323972)