### PR TITLE
backport:  `dynamodb` Table validation error when GSI `range_key` is empty

### DIFF
--- a/.changelog/46602.txt
+++ b/.changelog/46602.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix GSI removal with `key_schema` syntax deleting all GSIs
+```

--- a/.changelog/47427.txt
+++ b/.changelog/47427.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Prevents validation error when global secondary index `range_key` is set to empty string
+```

--- a/.changelog/47867.txt
+++ b/.changelog/47867.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Ensure diffs are shown for GSI hash key type changes
+```

--- a/internal/errs/diag.go
+++ b/internal/errs/diag.go
@@ -184,6 +184,15 @@ func NewAttributeConflictsWhenWillBeError(path, otherPath cty.Path, otherValue s
 	)
 }
 
+// NewInvalidValueAttributeWillBeError returns a warning diagnostic indicating that the attribute at the given path
+// has an invalid value.
+// This is intended to be used for situations where the invalid value will become an error in a future release.
+func NewInvalidValueAttributeWillBeError(path cty.Path, detail string) diag.Diagnostic {
+	return willBeError(
+		NewInvalidValueAttributeError(path, detail),
+	)
+}
+
 func PathString(path cty.Path) string {
 	var buf strings.Builder
 	for i, step := range path {

--- a/internal/service/dynamodb/exports_test.go
+++ b/internal/service/dynamodb/exports_test.go
@@ -36,6 +36,7 @@ var (
 	TableNameFromARN                             = tableNameFromARN
 	TableReplicaParseResourceID                  = tableReplicaParseResourceID
 	UpdateDiffGSI                                = updateDiffGSI
+	CheckIfGSIRecreateAttributesChanged          = checkIfGSIRecreateAttributesChanged
 )
 
 const (

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2207,11 +2207,26 @@ func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
 
 	newAttributes := stripGSIUpdatableAttributes(newMap)
 
+	// Config uses either hash_key or key_schema syntax, but not both.
+	// If hash_key matches, key_schema is redundant, remove it.
 	oHk, oOk := oldAttributes["hash_key"]
 	nHk, nOk := newAttributes["hash_key"]
 	if oOk && nOk && oHk == nHk && oHk != "" {
 		delete(oldAttributes, "key_schema")
 		delete(newAttributes, "key_schema")
+	}
+
+	// If key_schema matches, hash_key/range_key are redundant, remove them.
+	// Only when key_schema is a non-empty list, to avoid matching on nil/empty defaults.
+	oKs, oKsOk := oldAttributes["key_schema"]
+	nKs, nKsOk := newAttributes["key_schema"]
+	oKsList, _ := oKs.([]any)
+	nKsList, _ := nKs.([]any)
+	if oKsOk && nKsOk && len(oKsList) > 0 && len(nKsList) > 0 && reflect.DeepEqual(oKs, nKs) {
+		delete(oldAttributes, "hash_key")
+		delete(newAttributes, "hash_key")
+		delete(oldAttributes, "range_key")
+		delete(newAttributes, "range_key")
 	}
 
 	return !reflect.DeepEqual(oldAttributes, newAttributes)

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -168,7 +168,7 @@ func resourceTable() *schema.Resource {
 							},
 						},
 					},
-					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName),
+					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName, names.AttrType),
 				},
 				"billing_mode": {
 					Type:             schema.TypeString,
@@ -1098,11 +1098,23 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	// will signal the problems.
 	var gsiUpdates []awstypes.GlobalSecondaryIndexUpdate
 
-	if d.HasChange("global_secondary_index") {
-		var err error
-		o, n := d.GetChange("global_secondary_index")
-		gsiUpdates, err = updateDiffGSI(o.(*schema.Set).List(), n.(*schema.Set).List(), newBillingMode)
+	if d.HasChanges("global_secondary_index", "attribute") {
+		oldGSI, newGSI := d.GetChange("global_secondary_index")
+		oldAttr, newAttr := d.GetChange("attribute")
 
+		oldAttrTypes := map[string]string{}
+		for _, a := range oldAttr.(*schema.Set).List() {
+			attr := a.(map[string]any)
+			oldAttrTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+		}
+		newAttrTypes := map[string]string{}
+		for _, a := range newAttr.(*schema.Set).List() {
+			attr := a.(map[string]any)
+			newAttrTypes[attr[names.AttrName].(string)] = attr[names.AttrType].(string)
+		}
+
+		var err error
+		gsiUpdates, err = updateDiffGSI(oldGSI.(*schema.Set).List(), newGSI.(*schema.Set).List(), newBillingMode, oldAttrTypes, newAttrTypes)
 		if err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), fmt.Errorf("computing GSI difference: %w", err))
 		}
@@ -2012,7 +2024,7 @@ func updateWarmThroughput(ctx context.Context, conn *dynamodb.Client, warmList [
 	return nil
 }
 
-func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
+func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode, oldAttrTypes, newAttrTypes map[string]string) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
 	// Transform slices into maps
 	oldGsis := make(map[string]any)
 	for _, gsidata := range oldGsi {
@@ -2117,7 +2129,7 @@ func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]aw
 			// ordinal of elements in its equality (which we actually don't care about)
 			nonKeyAttributesChanged := checkIfNonKeyAttributesChanged(oldMap, newMap)
 
-			recreateAttributesChanged := checkIfGSIRecreateAttributesChanged(oldMap, newMap)
+			recreateAttributesChanged := checkIfGSIRecreateAttributesChanged(oldMap, newMap, oldAttrTypes, newAttrTypes)
 
 			gsiNeedsRecreate := nonKeyAttributesChanged || recreateAttributesChanged || warmThroughPutDecreased
 
@@ -2205,7 +2217,7 @@ func checkIfNonKeyAttributesChanged(oldMap, newMap map[string]any) bool {
 	return oldNkaExists != newNkaExists
 }
 
-func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
+func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any, oldAttrTypes, newAttrTypes map[string]string) bool {
 	oldAttributes := stripGSIUpdatableAttributes(oldMap)
 
 	newAttributes := stripGSIUpdatableAttributes(newMap)
@@ -2232,7 +2244,21 @@ func checkIfGSIRecreateAttributesChanged(oldMap, newMap map[string]any) bool {
 		delete(newAttributes, "range_key")
 	}
 
-	return !reflect.DeepEqual(oldAttributes, newAttributes)
+	if !reflect.DeepEqual(oldAttributes, newAttributes) {
+		return true
+	}
+
+	// Check if the type of any key attribute used by this GSI changed.
+	for _, keyAttr := range []string{oldMap["hash_key"].(string), oldMap["range_key"].(string)} {
+		if keyAttr == "" {
+			continue
+		}
+		if oldAttrTypes[keyAttr] != newAttrTypes[keyAttr] {
+			return true
+		}
+	}
+
+	return false
 }
 
 func deleteTable(ctx context.Context, conn *dynamodb.Client, tableName string) error {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -187,10 +187,11 @@ func resourceTable() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"hash_key": {
-								Type:       schema.TypeString,
-								Optional:   true,
-								Computed:   true,
-								Deprecated: "hash_key is deprecated. Use key_schema instead.",
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								Deprecated:   "hash_key is deprecated. Use key_schema instead.",
+								ValidateFunc: validation.StringIsNotEmpty,
 							},
 							"key_schema": {
 								Type:     schema.TypeList,
@@ -199,8 +200,9 @@ func resourceTable() *schema.Resource {
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"attribute_name": {
-											Type:     schema.TypeString,
-											Required: true,
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringIsNotEmpty,
 										},
 										"key_type": {
 											Type:             schema.TypeString,
@@ -226,9 +228,10 @@ func resourceTable() *schema.Resource {
 								ValidateDiagFunc: enum.Validate[awstypes.ProjectionType](),
 							},
 							"range_key": {
-								Type:       schema.TypeString,
-								Optional:   true,
-								Deprecated: "range_key is deprecated. Use key_schema instead.",
+								Type:             schema.TypeString,
+								Optional:         true,
+								Deprecated:       "range_key is deprecated. Use key_schema instead.",
+								ValidateDiagFunc: verify.WarnStringIsNotEmpty,
 							},
 							"read_capacity": {
 								Type:     schema.TypeInt,
@@ -3201,7 +3204,7 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 					indexedAttributes[hashKey.AsString()] = true
 				}
 				rangeKey := v.GetAttr("range_key")
-				if rangeKey.IsKnown() && !rangeKey.IsNull() {
+				if rangeKey.IsKnown() && !rangeKey.IsNull() && rangeKey.AsString() != "" {
 					indexedAttributes[rangeKey.AsString()] = true
 				}
 				keySchema := v.GetAttr("key_schema")

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -3247,7 +3247,7 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 	// validate against remote as well, because we're using the remote state as a bridge between the table and gsi resources
 	remoteGSIAttributes := map[string]bool{}
 	name := planRaw.GetAttr(names.AttrName)
-	if name.IsKnown() {
+	if name.IsKnown() && d.Id() != "" {
 		table, err := findTableByName(ctx, conn, name.AsString())
 		if err != nil && !retry.NotFound(err) {
 			return err

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1796,6 +1796,112 @@ func normalizeGSIMapValue(v map[string]any) map[string]any {
 	return result
 }
 
+func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		Old      map[string]any
+		New      map[string]any
+		Expected bool
+	}{
+		"key_schema syntax unchanged": {
+			// State has hash_key/range_key, config only has key_schema
+			Old: map[string]any{
+				names.AttrName:    "gsi2",
+				"hash_key":        "gsi2pk",
+				"range_key":       "gsi2sk",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "gsi2pk", "key_type": "HASH"},
+					map[string]any{"attribute_name": "gsi2sk", "key_type": "RANGE"},
+				},
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi2",
+				"hash_key":        "",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "gsi2pk", "key_type": "HASH"},
+					map[string]any{"attribute_name": "gsi2sk", "key_type": "RANGE"},
+				},
+			},
+			Expected: false,
+		},
+		"hash_key syntax unchanged": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "pk", "key_type": "HASH"},
+				},
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "pk", "key_type": "HASH"},
+				},
+			},
+			Expected: false,
+		},
+		"hash_key changed with nil key_schema": {
+			// Both maps have key_schema: nil (hash_key syntax), but hash_key differs
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk1",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk2",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			Expected: true,
+		},
+		"key_schema changed": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk1",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "pk1", "key_type": "HASH"},
+				},
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "pk2", "key_type": "HASH"},
+				},
+			},
+			Expected: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New)
+			if got != tc.Expected {
+				t.Errorf("expected %v, got %v", tc.Expected, got)
+			}
+		})
+	}
+}
+
 func TestAccDynamoDBTable_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
@@ -3038,6 +3144,101 @@ func TestAccDynamoDBTable_GSI_keySchema_removeRangeKey(t *testing.T) {
 							names.AttrName:    knownvalue.StringExact("GSI"),
 							"projection_type": tfknownvalue.StringExact(awstypes.ProjectionTypeKeysOnly),
 							"range_key":       knownvalue.StringExact("TestGSIRangeKey"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_GSI_keySchema_removeGSI(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_GSI_keySchema_threeGSIs(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("global_secondary_index"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrName:    knownvalue.StringExact("att1-index"),
+							"projection_type": tfknownvalue.StringExact(awstypes.ProjectionTypeAll),
+							"key_schema": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"attribute_name": knownvalue.StringExact("att1"),
+									"key_type":       tfknownvalue.StringExact(awstypes.KeyTypeHash),
+								}),
+							}),
+						}),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrName:    knownvalue.StringExact("att2-index"),
+							"projection_type": tfknownvalue.StringExact(awstypes.ProjectionTypeAll),
+							"key_schema": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"attribute_name": knownvalue.StringExact("att2"),
+									"key_type":       tfknownvalue.StringExact(awstypes.KeyTypeHash),
+								}),
+							}),
+						}),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrName:    knownvalue.StringExact("att3-index"),
+							"projection_type": tfknownvalue.StringExact(awstypes.ProjectionTypeAll),
+							"key_schema": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"attribute_name": knownvalue.StringExact("att3"),
+									"key_type":       tfknownvalue.StringExact(awstypes.KeyTypeHash),
+								}),
+							}),
+						}),
+					})),
+				},
+			},
+			{
+				Config: testAccTableConfig_GSI_keySchema_twoGSIs(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("global_secondary_index"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrName:    knownvalue.StringExact("att2-index"),
+							"projection_type": tfknownvalue.StringExact(awstypes.ProjectionTypeAll),
+							"key_schema": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"attribute_name": knownvalue.StringExact("att2"),
+									"key_type":       tfknownvalue.StringExact(awstypes.KeyTypeHash),
+								}),
+							}),
+						}),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrName:    knownvalue.StringExact("att3-index"),
+							"projection_type": tfknownvalue.StringExact(awstypes.ProjectionTypeAll),
+							"key_schema": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"attribute_name": knownvalue.StringExact("att3"),
+									"key_type":       tfknownvalue.StringExact(awstypes.KeyTypeHash),
+								}),
+							}),
 						}),
 					})),
 				},
@@ -9304,6 +9505,106 @@ resource "aws_dynamodb_table" "test" {
     projection_type = "ALL"
     write_capacity  = 1
     read_capacity   = 1
+  }
+}
+`, rName)
+}
+
+func testAccTableConfig_GSI_keySchema_threeGSIs(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name         = %[1]q
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "att1"
+    type = "S"
+  }
+
+  attribute {
+    name = "att2"
+    type = "S"
+  }
+
+  attribute {
+    name = "att3"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name = "att1-index"
+    key_schema {
+      attribute_name = "att1"
+      key_type       = "HASH"
+    }
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name = "att2-index"
+    key_schema {
+      attribute_name = "att2"
+      key_type       = "HASH"
+    }
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name = "att3-index"
+    key_schema {
+      attribute_name = "att3"
+      key_type       = "HASH"
+    }
+    projection_type = "ALL"
+  }
+}
+`, rName)
+}
+
+func testAccTableConfig_GSI_keySchema_twoGSIs(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name         = %[1]q
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "att2"
+    type = "S"
+  }
+
+  attribute {
+    name = "att3"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name = "att2-index"
+    key_schema {
+      attribute_name = "att2"
+      key_type       = "HASH"
+    }
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name = "att3-index"
+    key_schema {
+      attribute_name = "att3"
+      key_type       = "HASH"
+    }
+    projection_type = "ALL"
   }
 }
 `, rName)

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -861,7 +861,7 @@ func TestUpdateDiffGSI_Provisioned(t *testing.T) {
 				tc.New[i] = normalizeGSIMapValue(v.(map[string]any))
 			}
 
-			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModeProvisioned)
+			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModeProvisioned, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1756,7 +1756,7 @@ func TestUpdateDiffGSI_OnDemand(t *testing.T) {
 				tc.New[i] = normalizeGSIMapValue(v.(map[string]any))
 			}
 
-			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModePayPerRequest)
+			ops, err := tfdynamodb.UpdateDiffGSI(tc.Old, tc.New, awstypes.BillingModePayPerRequest, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1800,9 +1800,11 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		Old      map[string]any
-		New      map[string]any
-		Expected bool
+		Old          map[string]any
+		New          map[string]any
+		OldAttrTypes map[string]string
+		NewAttrTypes map[string]string
+		Expected     bool
 	}{
 		"key_schema syntax unchanged": {
 			// State has hash_key/range_key, config only has key_schema
@@ -1888,13 +1890,70 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 			},
 			Expected: true,
 		},
+		"hash_key attribute type changed S to N": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"alternate_id": "S"},
+			NewAttrTypes: map[string]string{"alternate_id": "N"},
+			Expected:     true,
+		},
+		"hash_key attribute type unchanged": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "alternate_id",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"alternate_id": "S"},
+			NewAttrTypes: map[string]string{"alternate_id": "S"},
+			Expected:     false,
+		},
+		"range_key attribute type changed S to N": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "sk",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "sk",
+				"projection_type": "ALL",
+				"key_schema":      nil,
+			},
+			OldAttrTypes: map[string]string{"pk": "S", "sk": "S"},
+			NewAttrTypes: map[string]string{"pk": "S", "sk": "N"},
+			Expected:     true,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New)
+			got := tfdynamodb.CheckIfGSIRecreateAttributesChanged(tc.Old, tc.New, tc.OldAttrTypes, tc.NewAttrTypes)
 			if got != tc.Expected {
 				t.Errorf("expected %v, got %v", tc.Expected, got)
 			}
@@ -4793,6 +4852,23 @@ func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -4804,18 +4880,73 @@ func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("N"),
+						}),
+					})),
+				},
 			},
 			{ // New attribute addition (index update)
 				Config: testAccTableConfig_twoAttributes(rName, "firstKey", "secondKey", "firstKey", "N", "secondKey", "S"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("N"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("secondKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+					})),
+				},
 			},
 			{ // Attribute removal (index update)
 				Config: testAccTableConfig_oneAttribute(rName, "firstKey", "firstKey", "S"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("attribute"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("staticHashKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName: knownvalue.StringExact("firstKey"),
+							names.AttrType: knownvalue.StringExact("S"),
+						}),
+					})),
+				},
 			},
 		},
 	})

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3252,6 +3252,63 @@ func TestAccDynamoDBTable_GSI_keySchema_removeGSI(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var table awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		CheckDestroy: testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.28.0",
+					},
+				},
+				Config: testAccTableConfig_GSI_rangeKeyExplicitEmptyString(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &table),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("global_secondary_index"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"hash_key":     knownvalue.StringExact(rName + "-hash"),
+							names.AttrName: knownvalue.StringExact(rName + "-index"),
+							"range_key":    knownvalue.StringExact(""),
+						}),
+					})),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccTableConfig_GSI_rangeKeyExplicitEmptyString(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &table),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -13097,6 +13154,47 @@ variable "key_schemas" {
   default = [{
     attribute_name = %[1]q
     key_type       = "HASH"
+  }]
+}
+`, rName)
+}
+
+func testAccTableConfig_GSI_rangeKeyExplicitEmptyString(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "%[1]s-hash"
+
+  attribute {
+    name = "%[1]s-hash"
+    type = "S"
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_index
+    content {
+      name               = global_secondary_index.value.name
+      hash_key           = global_secondary_index.value.hash_key
+      non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
+      projection_type    = global_secondary_index.value.projection_type
+      range_key          = lookup(global_secondary_index.value, "range_key", null)
+      read_capacity      = global_secondary_index.value.read_capacity
+      write_capacity     = global_secondary_index.value.write_capacity
+    }
+  }
+}
+
+variable "global_secondary_index" {
+  default = [{
+    name               = "%[1]s-index"
+    hash_key           = "%[1]s-hash"
+    range_key          = ""
+    projection_type    = "ALL"
+    non_key_attributes = []
+    read_capacity      = 1
+    write_capacity     = 1
   }]
 }
 `, rName)

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -569,3 +569,18 @@ func CaseInsensitiveMatchDeprecation(valid []string) schema.SchemaValidateDiagFu
 		return diags
 	}
 }
+
+func WarnStringIsNotEmpty(v any, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch s := v.(type) {
+	case string:
+		if s == "" {
+			diags = append(diags, errs.NewInvalidValueAttributeWillBeError(path, "Value must not be an empty string"))
+		}
+	default:
+		diags = append(diags, errs.NewIncorrectValueTypeAttributeError(path, "string"))
+	}
+
+	return diags
+}

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -900,3 +900,31 @@ func TestCaseInsensitiveMatchDeprecation(t *testing.T) {
 		})
 	}
 }
+
+func TestWarnStringIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value    any
+		wantDiag bool
+	}{
+		"empty string": {
+			value:    "",
+			wantDiag: true,
+		},
+		"non-empty string": {
+			value: "value",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := WarnStringIsNotEmpty(tt.value, cty.Path{})
+			if got, want := len(diags) > 0, tt.wantDiag; got != want {
+				t.Errorf("got = %v, want = %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
cherrypicks upstream fixes for dynamodb Table to `v6.34.0`