### PR TITLE
aws_dynamodb_table: use RawConfig while validating GSI attributes

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -3219,12 +3219,21 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 		}
 	}
 
-	// schema.ResourceDiff.GetOk() has a bug when retrieving a list inside a set
-	planRaw := d.GetRawPlan()
-	if planRaw.IsKnown() && !planRaw.IsNull() {
-		planGSI := planRaw.GetAttr("global_secondary_index")
-		if planGSI.IsKnown() && !planGSI.IsNull() {
-			for v := range tfcty.ValueElementValues(planGSI) {
+	// schema.ResourceDiff.GetOk() has a bug retrieving a list inside a set (the
+	// nested list decodes to nil elements), so we read from the raw config
+	// instead. GetRawPlan() is deliberately avoided:
+	// Upjet has a limitation here, SDKv2 external client sets RawPlan
+	// to the prior state, which misses a newly configured GSI. The raw config
+	// is sufficient here even though it omits computed fields: hash_key/range_key
+	// and key_schema are two syntaxes for the same keys, so whichever one the
+	// user wrote carries every indexed attribute name. The computed counterpart
+	// is only ever a mirror of the same names (both are flattened from the same
+	// API KeySchema), so it can never contribute a name absent from config.
+	configRaw := d.GetRawConfig()
+	if configRaw.IsKnown() && !configRaw.IsNull() {
+		configGSI := configRaw.GetAttr("global_secondary_index")
+		if configGSI.IsKnown() && !configGSI.IsNull() {
+			for v := range tfcty.ValueElementValues(configGSI) {
 				hashKey := v.GetAttr("hash_key")
 				if hashKey.IsKnown() && !hashKey.IsNull() {
 					indexedAttributes[hashKey.AsString()] = true
@@ -3237,7 +3246,9 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 				if keySchema.IsKnown() && !keySchema.IsNull() {
 					for v := range tfcty.ValueElementValues(keySchema) {
 						name := v.GetAttr("attribute_name")
-						indexedAttributes[name.AsString()] = true
+						if name.IsKnown() && !name.IsNull() {
+							indexedAttributes[name.AsString()] = true
+						}
 					}
 				}
 			}
@@ -3246,8 +3257,8 @@ func validateTableAttributes(ctx context.Context, d *schema.ResourceDiff, meta a
 
 	// validate against remote as well, because we're using the remote state as a bridge between the table and gsi resources
 	remoteGSIAttributes := map[string]bool{}
-	name := planRaw.GetAttr(names.AttrName)
-	if name.IsKnown() && d.Id() != "" {
+	name := configRaw.GetAttr(names.AttrName)
+	if name.IsKnown() && !name.IsNull() && d.Id() != "" {
 		table, err := findTableByName(ctx, conn, name.AsString())
 		if err != nil && !retry.NotFound(err) {
 			return err


### PR DESCRIPTION
## Summary

`validateTableAttributes` (a `CustomizeDiff` function) collects every attribute referenced by a table's key schema and global secondary indexes, then checks that the set matches the declared `attribute` blocks. To read the GSI attribute names it was using `d.GetRawPlan()`. This changes it to `d.GetRawConfig()`.

## Why `GetOk`/`Get` can't be used here

The `global_secondary_index` block is a `TypeSet`, and each element contains `key_schema`, a nested `TypeList`. `schema.ResourceDiff`'s typed getters read through the SDK's flatmap-based `DiffFieldReader`, which addresses set elements by a content **hash**. A collection nested beneath that hash prefix doesn't resolve during a diff: `d.GetOk("global_secondary_index")` returns each element's `key_schema` as a slice of the correct **length** but with `nil` elements — the `attribute_name`/`key_type` sub-fields are never decoded (reading them panics). Plain string fields on the element (`hash_key`, `range_key`, `name`) read fine, which is why the LSI block above can use `GetOk`. This is a known SDKv2 limitation with no flatmap layer in the plugin-framework, so it won't be fixed upstream. That's why the code reaches for a raw cty accessor, which is structural and sidesteps the field readers entirely.

## Why switch from `GetRawPlan` to `GetRawConfig` works for this 

For the particular resource and scenario here: `GetRawConfig` carries everything this function needs, even though it omits computed fields.

The natural objection to config is that it lacks computed values — and `key_schema` (and `hash_key`/`range_key`) are all `Computed`. It works anyway because `hash_key`/`range_key` and `key_schema` are **two syntaxes for the same keys**, and the resource keeps them mirror images:

- **Config → API** (`expandKeySchema`): the `KeySchema` sent to AWS is built *only* from user-provided fields — either `key_schema[].attribute_name`, or `hash_key` (guarded by `len(key_schema)==0`) plus `range_key`. Nothing else can introduce a key attribute name.
- **API → computed fields** (`flattenTableGlobalSecondaryIndex`): on read-back, *both* representations are populated from that same `KeySchema`.

So the round trip is:

```
config (hash_key/range_key  XOR  key_schema)
  → expandKeySchema → API KeySchema        (single source of truth)
  → flatten → BOTH hash_key/range_key AND key_schema  (computed)
```

Whichever syntax the user wrote is present in config, and the computed counterpart is only ever a re-encoding of the *same* names. Since `validateTableAttributes` only needs the **set of indexed attribute names**, the missing computed field is pure redundancy — reading config yields the identical set. Edge cases hold up: a GSI must declare a hash key so at least one syntax is always in config; a GSI present only in remote state (not config) is already covered by the separate `remoteGSIAttributes` bridge below; and an interpolated/unknown name is unknown in the plan too and is skipped by the `IsKnown()` guards. Reading config is arguably *more* correct here, since the function validates the user's configuration.

## Changes

- `validateTableAttributes`: GSI traversal and the `name` lookup now source from `d.GetRawConfig()` instead of `d.GetRawPlan()`.
- Added `IsKnown() && !IsNull()` guards on `attribute_name` (previously unguarded — would panic on an unknown/interpolated key name) and on `name`.
- Updated the explanatory comment.
