### PR TITLE
fix(backup): add update path for vault lock config

### DIFF
--- a/.changelog/ext-338.txt
+++ b/.changelog/ext-338.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_backup_vault_lock_configuration: Support updating `changeable_for_days`, `max_retention_days`, and `min_retention_days` in place while the vault lock is still changeable, instead of requiring resource replacement
+```
+
+```release-note:enhancement
+resource/aws_backup_vault_lock_configuration: Add `locked` and `lock_date` attributes
+```
+
+```release-note:bug
+resource/aws_backup_vault_lock_configuration: Reject `changeable_for_days` values greater than `36500` at plan time
+```

--- a/internal/service/backup/vault_lock_configuration.go
+++ b/internal/service/backup/vault_lock_configuration.go
@@ -8,6 +8,7 @@ package backup
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,6 +28,7 @@ func resourceVaultLockConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVaultLockConfigurationCreate,
 		ReadWithoutTimeout:   resourceVaultLockConfigurationRead,
+		UpdateWithoutTimeout: resourceVaultLockConfigurationUpdate,
 		DeleteWithoutTimeout: resourceVaultLockConfigurationDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -48,18 +50,23 @@ func resourceVaultLockConfiguration() *schema.Resource {
 				"changeable_for_days": {
 					Type:         schema.TypeInt,
 					Optional:     true,
-					ForceNew:     true,
-					ValidateFunc: validation.IntAtLeast(3),
+					ValidateFunc: validation.IntBetween(3, 36500),
+				},
+				"lock_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"locked": {
+					Type:     schema.TypeBool,
+					Computed: true,
 				},
 				"max_retention_days": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					ForceNew: true,
 				},
 				"min_retention_days": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					ForceNew: true,
 				},
 			}
 		},
@@ -116,10 +123,50 @@ func resourceVaultLockConfigurationRead(ctx context.Context, d *schema.ResourceD
 
 	d.Set("backup_vault_arn", output.BackupVaultArn)
 	d.Set("backup_vault_name", output.BackupVaultName)
+	if output.LockDate != nil {
+		d.Set("lock_date", output.LockDate.Format(time.RFC3339))
+	} else {
+		d.Set("lock_date", nil)
+	}
+	d.Set("locked", output.Locked)
 	d.Set("max_retention_days", output.MaxRetentionDays)
 	d.Set("min_retention_days", output.MinRetentionDays)
 
 	return diags
+}
+
+func resourceVaultLockConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).BackupClient(ctx)
+
+	// PutBackupVaultLockConfiguration replaces the entire lock configuration, so
+	// send the full desired configuration. Do not gate changeable_for_days behind
+	// HasChange: omitting it selects governance mode, silently demoting a
+	// compliance-mode lock, and the API never returns the field, so the demotion
+	// would go undetected.
+	input := &backup.PutBackupVaultLockConfigurationInput{
+		BackupVaultName: aws.String(d.Id()),
+	}
+
+	if v, ok := d.GetOk("changeable_for_days"); ok {
+		input.ChangeableForDays = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("max_retention_days"); ok {
+		input.MaxRetentionDays = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("min_retention_days"); ok {
+		input.MinRetentionDays = aws.Int64(int64(v.(int)))
+	}
+
+	_, err := conn.PutBackupVaultLockConfiguration(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Backup Vault Lock Configuration (%s): %s", d.Id(), err)
+	}
+
+	return append(diags, resourceVaultLockConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceVaultLockConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/backup/vault_lock_configuration_test.go
+++ b/internal/service/backup/vault_lock_configuration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/backup"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,6 +18,81 @@ import (
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+// Vault Lock retention values must be updatable in place: they are mutable via
+// PutBackupVaultLockConfiguration before the lock date, and marking them
+// ForceNew sends declarative callers (e.g. upjet, which refuses replacements)
+// into a permanent update loop.
+func TestVaultLockConfigurationUpdateSchema(t *testing.T) {
+	t.Parallel()
+
+	r := tfbackup.ResourceVaultLockConfiguration()
+
+	if r.UpdateWithoutTimeout == nil {
+		t.Error("resource must define UpdateWithoutTimeout")
+	}
+
+	type want struct {
+		ForceNew bool
+		Computed bool
+	}
+	cases := map[string]struct {
+		args string
+		want want
+	}{
+		"backup_vault_name is the identity and stays ForceNew": {args: "backup_vault_name", want: want{ForceNew: true}},
+		"changeable_for_days updatable":                        {args: "changeable_for_days"},
+		"max_retention_days updatable":                         {args: "max_retention_days"},
+		"min_retention_days updatable":                         {args: "min_retention_days"},
+		"lock_date exposed as computed":                        {args: "lock_date", want: want{Computed: true}},
+		"locked exposed as computed":                           {args: "locked", want: want{Computed: true}},
+	}
+
+	schemaMap := r.SchemaMap()
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			s, ok := schemaMap[tc.args]
+			if !ok {
+				t.Fatalf("attribute %q not found in schema", tc.args)
+			}
+
+			got := want{ForceNew: s.ForceNew, Computed: s.Computed}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("attribute %q (-want +got):\n%s", tc.args, diff)
+			}
+		})
+	}
+}
+
+// AWS bounds ChangeableForDays to [3, 36500]; out-of-range values must fail at
+// plan time, not at apply time.
+func TestVaultLockConfigurationChangeableForDaysValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		args int
+		want bool
+	}{
+		"below minimum": {args: 2, want: true},
+		"minimum":       {args: 3},
+		"maximum":       {args: 36500},
+		"above maximum": {args: 36501, want: true},
+	}
+
+	validate := tfbackup.ResourceVaultLockConfiguration().SchemaMap()["changeable_for_days"].ValidateFunc
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, errs := validate(tc.args, "changeable_for_days")
+			if got := len(errs) > 0; got != tc.want {
+				t.Errorf("validate(%d): wantErr = %t, got errors %v", tc.args, tc.want, errs)
+			}
+		})
+	}
+}
 
 func TestAccBackupVaultLockConfiguration_basic(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/website/docs/r/backup_vault_lock_configuration.html.markdown
+++ b/website/docs/r/backup_vault_lock_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an AWS Backup vault lock configuration resource.
 
+~> **Note:** Updates replace the whole lock configuration via [`PutBackupVaultLockConfiguration`](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_PutBackupVaultLockConfiguration.html) and are only possible while the vault lock is changeable: always in `governance` mode, and until the lock date in `compliance` mode. On and after `lock_date` the vault lock is immutable — AWS permanently rejects any update or deletion of the lock configuration. AWS computes the lock date from the time of the call, so updating a `compliance` mode configuration during its grace period may move `lock_date` forward.
+
 ## Example Usage
 
 ```terraform
@@ -27,7 +29,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `backup_vault_name` - (Required) Name of the backup vault to add a lock configuration for.
-* `changeable_for_days` - (Optional) The number of days before the lock date. If omitted creates a vault lock in `governance` mode, otherwise it will create a vault lock in `compliance` mode.
+* `changeable_for_days` - (Optional) The number of days before the lock date, between `3` and `36500`. If omitted creates a vault lock in `governance` mode, otherwise it will create a vault lock in `compliance` mode.
 * `max_retention_days` - (Optional) The maximum retention period that the vault retains its recovery points.
 * `min_retention_days` - (Optional) The minimum retention period that the vault retains its recovery points.
 
@@ -37,6 +39,8 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `backup_vault_name` - The name of the vault.
 * `backup_vault_arn` - The ARN of the vault.
+* `locked` - Whether Vault Lock is currently protecting the backup vault.
+* `lock_date` - Date and time, in RFC3339 format, when the vault lock becomes immutable. Not set in `governance` mode.
 
 ## Import
 


### PR DESCRIPTION
aws_backup_vault_lock_configuration registered Create/Read/Delete only and marked every argument ForceNew. When a declarative caller (upjet) reaches the update path — e.g. observed retention differs from spec on an unlocked vault — upjet's assertNoForceNew refuses the replacement and the resource retries forever (EXT-338, reported in Pylon #1805).

AWS permits changing the lock configuration via the idempotent PutBackupVaultLockConfiguration at any time in governance mode and until the lock date in compliance mode, so an in-place update path is the accurate model:

- drop ForceNew from changeable_for_days, max_retention_days and min_retention_days; backup_vault_name remains the ForceNew identity
- add UpdateWithoutTimeout re-sending the full desired configuration; changeable_for_days is deliberately not gated behind HasChange, because omitting it selects governance mode and would silently demote a compliance-mode lock (the API never returns the field, so the demotion would be undetectable)
- expose locked and lock_date as computed attributes so the immutability deadline is visible in state (status.atProvider)
- validate changeable_for_days against the documented [3, 36500]

Once the lock date passes, updates keep failing by design — now with the real AWS error instead of a local refusal.

#### Tested E2E + update path with following MRs:

Apply

```yaml
apiVersion: backup.aws.upbound.io/v1beta1
kind: VaultLockConfiguration
metadata:
  annotations:
    crossplane.io/external-create-pending: "2026-07-30T05:30:41Z"
    crossplane.io/external-create-succeeded: "2026-07-30T05:30:41Z"
    crossplane.io/external-name: vaultlock-buiqdwhu
    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
  creationTimestamp: "2026-07-30T05:30:40Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 3
  labels:
    testing.upbound.io/example-name: vaultlockconfiguration
  name: vaultlockconfiguration
  resourceVersion: "3659"
  uid: 38b25691-0853-4676-adc8-2116fc30e88f
spec:
  deletionPolicy: Delete
  forProvider:
    backupVaultName: vaultlock-buiqdwhu
    backupVaultNameRef:
      name: vaultlock-buiqdwhu
    backupVaultNameSelector:
      matchLabels:
        testing.upbound.io/example-name: vaultlockconfiguration
    changeableForDays: 3
    maxRetentionDays: 1200
    minRetentionDays: 7
    region: us-west-1
  initProvider: {}
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    backupVaultArn: arn:aws:backup:us-west-1:153891904029:backup-vault:vaultlock-buiqdwhu
    backupVaultName: vaultlock-buiqdwhu
    changeableForDays: 3
    id: vaultlock-buiqdwhu
    lockDate: "2026-08-02T05:30:41Z"
    locked: true
    maxRetentionDays: 1200
    minRetentionDays: 7
    region: us-west-1
  conditions:
  - lastTransitionTime: "2026-07-30T05:30:41Z"
    observedGeneration: 3
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2026-07-30T05:30:43Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2026-07-30T05:30:42Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```

Update - lockDate gets updated on every operation changing changeableForDays, maxRetentionDays and minRetentionDays

```shell
kubectl patch vaultlockconfiguration.backup.aws.upbound.io/vaultlockconfiguration --type=merge -p '{"spec":{"forProvider":{"minRetentionDays": 14}}}'
```

```yaml
piVersion: backup.aws.upbound.io/v1beta1
kind: VaultLockConfiguration
metadata:
  annotations:
    crossplane.io/external-create-pending: "2026-07-30T05:30:41Z"
    crossplane.io/external-create-succeeded: "2026-07-30T05:30:41Z"
    crossplane.io/external-name: vaultlock-buiqdwhu
    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
  creationTimestamp: "2026-07-30T05:30:40Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 4
  labels:
    testing.upbound.io/example-name: vaultlockconfiguration
  name: vaultlockconfiguration
  resourceVersion: "3947"
  uid: 38b25691-0853-4676-adc8-2116fc30e88f
spec:
  deletionPolicy: Delete
  forProvider:
    backupVaultName: vaultlock-buiqdwhu
    backupVaultNameRef:
      name: vaultlock-buiqdwhu
    backupVaultNameSelector:
      matchLabels:
        testing.upbound.io/example-name: vaultlockconfiguration
    changeableForDays: 3
    maxRetentionDays: 1200
    minRetentionDays: 14
    region: us-west-1
  initProvider: {}
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    backupVaultArn: arn:aws:backup:us-west-1:153891904029:backup-vault:vaultlock-buiqdwhu
    backupVaultName: vaultlock-buiqdwhu
    changeableForDays: 3
    id: vaultlock-buiqdwhu
    lockDate: "2026-08-02T05:32:40Z"
    locked: true
    maxRetentionDays: 1200
    minRetentionDays: 14
    region: us-west-1
  conditions:
  - lastTransitionTime: "2026-07-30T05:32:40Z"
    observedGeneration: 4
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2026-07-30T05:30:43Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2026-07-30T05:30:42Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```
