### PR TITLE
[Backport upjet-v5.82.2] Fix a problem that aws_rds_instance_state can't start a stopped RDS instance

### DIFF
--- a/.changelog/45791.txt
+++ b/.changelog/45791.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_instance_state: Fix aws_rds_instance_state can not start a stopped RDS instance
+```

--- a/internal/service/rds/instance_state.go
+++ b/internal/service/rds/instance_state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -19,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -86,7 +89,7 @@ func (r *resourceInstanceState) Create(ctx context.Context, req resource.CreateR
 
 	instanceID := plan.Identifier.ValueString()
 
-	instance, err := waitDBInstanceAvailable(ctx, conn, instanceID, r.CreateTimeout(ctx, plan.Timeouts))
+	instance, err := waitDBInstanceReadyForStateChange(ctx, conn, instanceID, r.CreateTimeout(ctx, plan.Timeouts))
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("waiting for RDS Instance (%s)", instanceID), err.Error())
 
@@ -139,7 +142,7 @@ func (r *resourceInstanceState) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	if _, err := waitDBInstanceAvailable(ctx, conn, state.Identifier.ValueString(), r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
+	if _, err := waitDBInstanceReadyForStateChange(ctx, conn, state.Identifier.ValueString(), r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("waiting for RDS Instance (%s)", state.Identifier.ValueString()), err.Error())
 
 		return
@@ -182,4 +185,47 @@ type resourceInstanceStateData struct {
 	Identifier types.String   `tfsdk:"identifier"`
 	State      types.String   `tfsdk:"state"`
 	Timeouts   timeouts.Value `tfsdk:"timeouts"`
+}
+
+func waitDBInstanceReadyForStateChange(ctx context.Context, conn *rds.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rdstypes.DBInstance, error) {
+	options := tfresource.Options{
+		PollInterval:              10 * time.Second,
+		Delay:                     1 * time.Minute,
+		ContinuousTargetOccurence: 3,
+	}
+	for _, fn := range optFns {
+		fn(&options)
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			instanceStatusBackingUp,
+			instanceStatusConfiguringEnhancedMonitoring,
+			instanceStatusConfiguringIAMDatabaseAuth,
+			instanceStatusConfiguringLogExports,
+			instanceStatusCreating,
+			instanceStatusMaintenance,
+			instanceStatusModifying,
+			instanceStatusMovingToVPC,
+			instanceStatusRebooting,
+			instanceStatusRenaming,
+			instanceStatusResettingMasterCredentials,
+			instanceStatusStarting,
+			instanceStatusStopping,
+			instanceStatusStorageFull,
+			instanceStatusUpgrading,
+		},
+		Target:  []string{instanceStatusStopped, instanceStatusAvailable, instanceStatusStorageOptimization},
+		Refresh: statusDBInstance(ctx, conn, id),
+		Timeout: timeout,
+	}
+	options.Apply(stateConf)
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*rdstypes.DBInstance); ok {
+		return output, err
+	}
+
+	return nil, err
 }

--- a/internal/service/rds/instance_state_test.go
+++ b/internal/service/rds/instance_state_test.go
@@ -80,6 +80,41 @@ func TestAccRDSInstanceState_update(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstanceState_update_start(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_instance_state.test"
+	stateAvailable := "available"
+	stateStopped := "stopped"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceStateConfig_basic(rName, stateStopped),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceStateExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIdentifier),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, stateStopped),
+				),
+			},
+			{
+				Config: testAccInstanceStateConfig_basic(rName, stateAvailable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceStateExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIdentifier),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, stateAvailable),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceStateExists(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]


### PR DESCRIPTION
This PR backports upstream PR#45791 to the `upjet-v5.82.2` branch.

Validated `InstanceState.rds` `spec.forProvider.state` transitions `available -> stopped -> available` with the following manifests using the Crossplane provider:

```yaml
apiVersion: rds.aws.upbound.io/v1beta3
kind: Instance
metadata:
  labels:
    testing.upbound.io/example-name: example-dbinstance
  name: example-dbinstance
spec:
  forProvider:
    allocatedStorage: 20
    autoGeneratePassword: true
    autoMinorVersionUpgrade: true
    backupRetentionPeriod: 14
    backupWindow: 09:46-10:16
    dbName: example
    engine: postgres
    instanceClass: db.t3.micro
    maintenanceWindow: Mon:00:00-Mon:03:00
    passwordSecretRef:
      key: password
      name: example-dbinstance
      namespace: upbound-system
    publiclyAccessible: false
    region: us-west-1
    skipFinalSnapshot: true
    storageEncrypted: true
    storageType: gp2
    username: adminuser
  writeConnectionSecretToRef:
    name: example-dbinstance-out
    namespace: default

---

apiVersion: rds.aws.upbound.io/v1beta1
kind: InstanceState
metadata:
  name: example-instancestate
spec:
  forProvider:
    identifierSelector:
      matchLabels:
        testing.upbound.io/example-name: example-dbinstance
    region: us-west-1
    state: available
```