### PR TITLE
[Backport upjet-v6.55.0] Fix a problem that aws_rds_instance_state can't start a stopped RDS instance

### DIFF
--- a/.changelog/45791.txt
+++ b/.changelog/45791.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_instance_state: Fix aws_rds_instance_state can not start a stopped RDS instance
+```

--- a/internal/service/rds/instance_state.go
+++ b/internal/service/rds/instance_state.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -25,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -84,7 +86,7 @@ func (r *instanceStateResource) Create(ctx context.Context, req resource.CreateR
 
 	instanceID := plan.Identifier.ValueString()
 
-	instance, err := waitDBInstanceAvailable(ctx, conn, instanceID, r.CreateTimeout(ctx, plan.Timeouts))
+	instance, err := waitDBInstanceReadyForStateChange(ctx, conn, instanceID, r.CreateTimeout(ctx, plan.Timeouts))
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("waiting for RDS Instance (%s)", instanceID), err.Error())
 
@@ -135,7 +137,7 @@ func (r *instanceStateResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	if _, err := waitDBInstanceAvailable(ctx, conn, state.Identifier.ValueString(), r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
+	if _, err := waitDBInstanceReadyForStateChange(ctx, conn, state.Identifier.ValueString(), r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("waiting for RDS Instance (%s)", state.Identifier.ValueString()), err.Error())
 
 		return
@@ -152,6 +154,48 @@ func (r *instanceStateResource) Update(ctx context.Context, req resource.UpdateR
 
 func (r *instanceStateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrIdentifier), req, resp)
+}
+
+func waitDBInstanceReadyForStateChange(ctx context.Context, conn *rds.Client, id string, timeout time.Duration) (*rdstypes.DBInstance, error) {
+	options := tfresource.Options{
+		PollInterval:              10 * time.Second,
+		Delay:                     1 * time.Minute,
+		ContinuousTargetOccurence: 3,
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			instanceStatusBackingUp,
+			instanceStatusConfiguringEnhancedMonitoring,
+			instanceStatusConfiguringIAMDatabaseAuth,
+			instanceStatusConfiguringLogExports,
+			instanceStatusCreating,
+			instanceStatusMaintenance,
+			instanceStatusModifying,
+			instanceStatusMovingToVPC,
+			instanceStatusRebooting,
+			instanceStatusRenaming,
+			instanceStatusResettingMasterCredentials,
+			instanceStatusStarting,
+			instanceStatusStopping,
+			instanceStatusStorageConfigUpgrade,
+			instanceStatusStorageFull,
+			instanceStatusStorageInitialization,
+			instanceStatusUpgrading,
+		},
+		Target:  []string{instanceStatusStopped, instanceStatusAvailable, instanceStatusStorageOptimization},
+		Refresh: statusDBInstance(conn, id),
+		Timeout: timeout,
+	}
+	options.Apply(stateConf)
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*rdstypes.DBInstance); ok {
+		return output, err
+	}
+
+	return nil, err
 }
 
 func updateInstanceState(ctx context.Context, conn *rds.Client, id string, currentState string, configuredState string, timeout time.Duration) error {

--- a/internal/service/rds/instance_state_test.go
+++ b/internal/service/rds/instance_state_test.go
@@ -79,6 +79,41 @@ func TestAccRDSInstanceState_update(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstanceState_update_start(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_instance_state.test"
+	stateAvailable := "available"
+	stateStopped := "stopped"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceStateConfig_basic(rName, stateStopped),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceStateExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIdentifier),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, stateStopped),
+				),
+			},
+			{
+				Config: testAccInstanceStateConfig_basic(rName, stateAvailable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceStateExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrIdentifier),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, stateAvailable),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceStateExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]


### PR DESCRIPTION
This PR backports upstream PR#45791 to the `upjet-v6.55.0` branch.

Validated `InstanceState.rds` `spec.forProvider.state` transitions `available -> stopped -> available` with the following manifests using the Crossplane provider:

```yaml
apiVersion: rds.aws.upbound.io/v1beta3
kind: Instance
metadata:
  annotations:
    uptest.upbound.io/timeout: "3600"
  labels:
    testing.upbound.io/example-name: example-dbinstance
  name: example-dbinstance-alper
spec:
  forProvider:
    allocatedStorage: 20
    autoGeneratePassword: true
    autoMinorVersionUpgrade: true
    dbName: example
    engine: postgres
    instanceClass: db.t3.micro
    passwordSecretRef:
      key: password
      name: example-dbinstance
      namespace: upbound-system
    publiclyAccessible: false
    region: us-west-1
    skipFinalSnapshot: true
    storageType: gp2
    username: adminuser
  writeConnectionSecretToRef:
    name: example-dbinstance-out
    namespace: default

---

apiVersion: rds.aws.upbound.io/v1beta1
kind: InstanceState
metadata:
  name: example-instancestate
spec:
  forProvider:
    identifierSelector:
      matchLabels:
        testing.upbound.io/example-name: example-dbinstance
    region: us-west-1
    state: available
```