### PR TITLE
Propagate Streaming Configuration to DynamoDB MRSC Replicas

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -26,6 +26,7 @@ import (
 	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfcty "github.com/hashicorp/terraform-provider-aws/internal/cty"
@@ -1009,6 +1010,14 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		if err := updateReplicaTags(ctx, conn, aws.ToString(output.TableArn), v.List(), keyValueTags(ctx, getTagsIn(ctx))); err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Id(), fmt.Errorf("replica tags: %w", err))
 		}
+
+		// Streaming configuration is not automatically propagated to MRSC replica
+		// tables, so propagate the configuration explicitly.
+		if d.Get("stream_enabled").(bool) {
+			if err := updateReplicaStreams(ctx, conn, d.Id(), v.List(), true, d.Get("stream_view_type").(string), false, d.Timeout(schema.TimeoutCreate)); err != nil {
+				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Id(), fmt.Errorf("replica streams: %w", err))
+			}
+		}
 	}
 
 	return append(diags, resourceTableRead(ctx, d, meta)...)
@@ -1514,6 +1523,22 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		}
 	}
 
+	// Updates to the streaming configuration are not automatically propagated
+	// to MRSC replica tables, so propagate the configuration explicitly.
+	// If there's a change in the view type, we will need to "cycle"
+	// the replica tables (first disable and then re-enable with the new config).
+	if d.HasChange("stream_enabled") || d.HasChange("stream_view_type") {
+		if replicas := d.Get("replica").(*schema.Set); replicas.Len() > 0 {
+			streamEnabled := d.Get("stream_enabled").(bool)
+			// Only stream_view_type changed while streams stay enabled: the replica
+			// stream must be cycled.
+			cycle := streamEnabled && !d.HasChange("stream_enabled") && d.HasChange("stream_view_type")
+			if err := updateReplicaStreams(ctx, conn, d.Id(), replicas.List(), streamEnabled, d.Get("stream_view_type").(string), cycle, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), err)
+			}
+		}
+	}
+
 	if d.HasChange("point_in_time_recovery") {
 		if err := updatePITR(ctx, conn, d.Id(), d.Get("point_in_time_recovery.0.enabled").(bool), aws.Int32(int32(d.Get("point_in_time_recovery.0.recovery_period_in_days").(int))), meta.(*conns.AWSClient).Region(ctx), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), err)
@@ -1609,6 +1634,118 @@ func cycleStreamEnabled(ctx context.Context, conn *dynamodb.Client, id string, s
 
 	if _, err := waitTableActive(ctx, conn, id, timeout); err != nil {
 		return fmt.Errorf("waiting for stream cycle: %w", err)
+	}
+
+	return nil
+}
+
+// updateReplicaStreams propagates the table-level DynamoDB Streams configuration to
+// each MRSC (multi-Region strong consistency) replica of the table.
+//
+// In MRSC mode the stream definition is NOT synchronized across replicas, so enabling
+// (or disabling) a stream on the primary Region does not affect the replicas; it must
+// be set per replica Region via a regional UpdateTable call.
+//
+// MREC (multi-Region eventual consistency) replicas are intentionally skipped: DynamoDB
+// uses their streams for replication, enables them automatically, keeps their stream
+// definition synchronized with the primary, and does not allow them to be disabled.
+// Attempting to modify a MREC replica's stream here would therefore either be redundant
+// or fail, so replicas are only touched when their consistency_mode is STRONG.
+func updateReplicaStreams(ctx context.Context, conn *dynamodb.Client, tableName string, replicas []any, streamEnabled bool, streamViewType string, cycle bool, timeout time.Duration) error {
+	for _, tfMapRaw := range replicas {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Only MRSC (STRONG) replicas need explicit stream propagation.
+		if v, ok := tfMap["consistency_mode"].(string); !ok || awstypes.MultiRegionConsistency(v) != awstypes.MultiRegionConsistencyStrong {
+			continue
+		}
+
+		region, ok := tfMap["region_name"].(string)
+		if !ok || region == "" {
+			continue
+		}
+
+		// stream_view_type changed while the stream remains enabled: the replica stream
+		// must be disabled and re-enabled to change the view type, otherwise DynamoDB
+		// returns "Table already has an enabled stream". This mirrors the primary Region.
+		if cycle {
+			if err := cycleReplicaStreamEnabled(ctx, conn, tableName, region, awstypes.StreamViewType(streamViewType), timeout); err != nil {
+				return fmt.Errorf("cycling stream specification for replica (%s): %w", region, err)
+			}
+			continue
+		}
+
+		streamSpec := &awstypes.StreamSpecification{
+			StreamEnabled: aws.Bool(streamEnabled),
+		}
+		if streamEnabled {
+			streamSpec.StreamViewType = awstypes.StreamViewType(streamViewType)
+		}
+
+		if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, streamSpec, timeout); err != nil {
+			return fmt.Errorf("updating stream specification for replica (%s): %w", region, err)
+		}
+	}
+
+	return nil
+}
+
+// cycleReplicaStreamEnabled disables and then re-enables the stream on
+// a replica region with streamViewType. It mirrors cycleStreamEnabled
+// for the primary region and is required to change the stream view type of
+// an already-enabled MRSC replica table's streaming configuration.
+func cycleReplicaStreamEnabled(ctx context.Context, conn *dynamodb.Client, tableName, region string, streamViewType awstypes.StreamViewType, timeout time.Duration) error {
+	if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, &awstypes.StreamSpecification{
+		StreamEnabled: aws.Bool(false),
+	}, timeout); err != nil {
+		return fmt.Errorf("disabling stream: %w", err)
+	}
+
+	if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, &awstypes.StreamSpecification{
+		StreamEnabled:  aws.Bool(true),
+		StreamViewType: streamViewType,
+	}, timeout); err != nil {
+		return fmt.Errorf("re-enabling stream: %w", err)
+	}
+
+	return nil
+}
+
+// updateReplicaStreamSpecification issues a regional UpdateTable to set the stream
+// specification on a single replica region and waits for that replica to become active.
+//
+// Global-table control-plane operations (e.g. an MRSC group still stabilizing after
+// replica creation) can briefly leave the table in the UPDATING state, during which a
+// further UpdateTable is rejected with ResourceInUseException. That error (and throttling)
+// is therefore retried here, mirroring how createReplicas issues its UpdateTable calls.
+func updateReplicaStreamSpecification(ctx context.Context, conn *dynamodb.Client, tableName, region string, streamSpec *awstypes.StreamSpecification, timeout time.Duration) error {
+	input := &dynamodb.UpdateTableInput{
+		TableName:           aws.String(tableName),
+		StreamSpecification: streamSpec,
+	}
+	optFn := func(o *dynamodb.Options) { o.Region = region }
+
+	err := tfresource.Retry(ctx, max(replicaUpdateTimeout, timeout), func(ctx context.Context) *tfresource.RetryError {
+		if _, err := conn.UpdateTable(ctx, input, optFn); err != nil {
+			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
+				return tfresource.RetryableError(err)
+			}
+			if errs.IsA[*awstypes.ResourceInUseException](err) {
+				return tfresource.RetryableError(err)
+			}
+			return tfresource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := waitReplicaActive(ctx, conn, tableName, region, timeout, replicaPropagationDelay); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -99,6 +99,7 @@ func resourceTable() *schema.Resource {
 				}
 				return nil
 			},
+			mrscReplicaTableDrift,
 			customdiff.ForceNewIfChange("restore_source_name", func(_ context.Context, old, new, meta any) bool {
 				// If they differ force new unless new is cleared
 				// https://github.com/hashicorp/terraform-provider-aws/issues/25214
@@ -459,6 +460,16 @@ func resourceTable() *schema.Resource {
 								Computed: true,
 							},
 							"stream_label": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							// Per-replica stream state (from the replica table's
+							// StreamSpecification), to detect MRSC replica stream drift.
+							"stream_enabled": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"stream_view_type": {
 								Type:     schema.TypeString,
 								Computed: true,
 							},
@@ -1014,7 +1025,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		// Streaming configuration is not automatically propagated to MRSC replica
 		// tables, so propagate the configuration explicitly.
 		if d.Get("stream_enabled").(bool) {
-			if err := updateReplicaStreams(ctx, conn, d.Id(), v.List(), true, d.Get("stream_view_type").(string), false, d.Timeout(schema.TimeoutCreate)); err != nil {
+			if err := updateReplicaStreams(ctx, conn, d.Id(), v.List(), true, d.Get("stream_view_type").(string), d.Timeout(schema.TimeoutCreate)); err != nil {
 				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Id(), fmt.Errorf("replica streams: %w", err))
 			}
 		}
@@ -1523,19 +1534,11 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		}
 	}
 
-	// Updates to the streaming configuration are not automatically propagated
-	// to MRSC replica tables, so propagate the configuration explicitly.
-	// If there's a change in the view type, we will need to "cycle"
-	// the replica tables (first disable and then re-enable with the new config).
-	if d.HasChange("stream_enabled") || d.HasChange("stream_view_type") {
-		if replicas := d.Get("replica").(*schema.Set); replicas.Len() > 0 {
-			streamEnabled := d.Get("stream_enabled").(bool)
-			// Only stream_view_type changed while streams stay enabled: the replica
-			// stream must be cycled.
-			cycle := streamEnabled && !d.HasChange("stream_enabled") && d.HasChange("stream_view_type")
-			if err := updateReplicaStreams(ctx, conn, d.Id(), replicas.List(), streamEnabled, d.Get("stream_view_type").(string), cycle, d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), err)
-			}
+	// Reconcile the DynamoDB Streams configuration of MRSC STRONG
+	// consistency-mode replicas to match the global-table level desired state.
+	if replicas := d.Get("replica").(*schema.Set); replicas.Len() > 0 {
+		if err := updateReplicaStreams(ctx, conn, d.Id(), replicas.List(), d.Get("stream_enabled").(bool), d.Get("stream_view_type").(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), err)
 		}
 	}
 
@@ -1639,19 +1642,13 @@ func cycleStreamEnabled(ctx context.Context, conn *dynamodb.Client, id string, s
 	return nil
 }
 
-// updateReplicaStreams propagates the table-level DynamoDB Streams configuration to
-// each MRSC (multi-Region strong consistency) replica of the table.
+// updateReplicaStreams propagates the global-table level streaming
+// configuration to each MRSC replica of the table when the consistency mode
+// is STRONG.
 //
-// In MRSC mode the stream definition is NOT synchronized across replicas, so enabling
-// (or disabling) a stream on the primary Region does not affect the replicas; it must
-// be set per replica Region via a regional UpdateTable call.
-//
-// MREC (multi-Region eventual consistency) replicas are intentionally skipped: DynamoDB
-// uses their streams for replication, enables them automatically, keeps their stream
-// definition synchronized with the primary, and does not allow them to be disabled.
-// Attempting to modify a MREC replica's stream here would therefore either be redundant
-// or fail, so replicas are only touched when their consistency_mode is STRONG.
-func updateReplicaStreams(ctx context.Context, conn *dynamodb.Client, tableName string, replicas []any, streamEnabled bool, streamViewType string, cycle bool, timeout time.Duration) error {
+// MREC replicas are skipped as DynamoDB uses streams for replication with that
+// consistency mode and hence streaming cannot be disabled/modified.
+func updateReplicaStreams(ctx context.Context, conn *dynamodb.Client, tableName string, replicas []any, streamEnabled bool, streamViewType string, timeout time.Duration) error {
 	for _, tfMapRaw := range replicas {
 		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
@@ -1668,35 +1665,59 @@ func updateReplicaStreams(ctx context.Context, conn *dynamodb.Client, tableName 
 			continue
 		}
 
-		// stream_view_type changed while the stream remains enabled: the replica stream
-		// must be disabled and re-enabled to change the view type, otherwise DynamoDB
-		// returns "Table already has an enabled stream". This mirrors the primary Region.
-		if cycle {
-			if err := cycleReplicaStreamEnabled(ctx, conn, tableName, region, awstypes.StreamViewType(streamViewType), timeout); err != nil {
-				return fmt.Errorf("cycling stream specification for replica (%s): %w", region, err)
+		curEnabled, curViewType, err := replicaStreamState(ctx, conn, tableName, region)
+		if err != nil {
+			return fmt.Errorf("reading stream state for replica (%s): %w", region, err)
+		}
+
+		switch {
+		case streamEnabled && !curEnabled:
+			// Replica table has streaming disabled, enable it.
+			if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, &awstypes.StreamSpecification{
+				StreamEnabled:  aws.Bool(true),
+				StreamViewType: awstypes.StreamViewType(streamViewType),
+			}, timeout); err != nil {
+				return fmt.Errorf("enabling stream for replica (%s): %w", region, err)
 			}
-			continue
+		case streamEnabled && curEnabled && string(curViewType) != streamViewType:
+			// Replica table has streaming enabled but is configured with the wrong
+			// view type, reconcile the drift.
+			if err := cycleReplicaStreamEnabled(ctx, conn, tableName, region, awstypes.StreamViewType(streamViewType), timeout); err != nil {
+				return fmt.Errorf("changing stream view type for replica (%s): %w", region, err)
+			}
+		case !streamEnabled && curEnabled:
+			// Replica table has streaming enabled, but in the desired state,
+			// it should be disabled.
+			if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, &awstypes.StreamSpecification{
+				StreamEnabled: aws.Bool(false),
+			}, timeout); err != nil {
+				return fmt.Errorf("disabling stream for replica (%s): %w", region, err)
+			}
 		}
-
-		streamSpec := &awstypes.StreamSpecification{
-			StreamEnabled: aws.Bool(streamEnabled),
-		}
-		if streamEnabled {
-			streamSpec.StreamViewType = awstypes.StreamViewType(streamViewType)
-		}
-
-		if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, streamSpec, timeout); err != nil {
-			return fmt.Errorf("updating stream specification for replica (%s): %w", region, err)
-		}
+		// Else, replica table is already in the desired state.
 	}
 
 	return nil
 }
 
-// cycleReplicaStreamEnabled disables and then re-enables the stream on
-// a replica region with streamViewType. It mirrors cycleStreamEnabled
-// for the primary region and is required to change the stream view type of
-// an already-enabled MRSC replica table's streaming configuration.
+// replicaStreamState returns the current DynamoDB streaming configuration
+// for the specified replica table in the specified region.
+// It returns whether streaming is actually enabled, and if it's enabled,
+// the configured streaming view type for the replica table.
+func replicaStreamState(ctx context.Context, conn *dynamodb.Client, tableName, region string) (bool, awstypes.StreamViewType, error) {
+	table, err := findTableByName(ctx, conn, tableName, func(o *dynamodb.Options) { o.Region = region })
+	if err != nil {
+		return false, "", err
+	}
+	if table.StreamSpecification == nil || !aws.ToBool(table.StreamSpecification.StreamEnabled) {
+		return false, "", nil
+	}
+	return true, table.StreamSpecification.StreamViewType, nil
+}
+
+// cycleReplicaStreamEnabled disables and then re-enables the stream on a replica Region
+// with streamViewType. It mirrors cycleStreamEnabled for the primary Region and is
+// required to change the stream view type of an already-enabled MRSC replica stream.
 func cycleReplicaStreamEnabled(ctx context.Context, conn *dynamodb.Client, tableName, region string, streamViewType awstypes.StreamViewType, timeout time.Duration) error {
 	if err := updateReplicaStreamSpecification(ctx, conn, tableName, region, &awstypes.StreamSpecification{
 		StreamEnabled: aws.Bool(false),
@@ -2759,6 +2780,15 @@ func enrichReplicas(ctx context.Context, conn *dynamodb.Client, arn, tableName s
 		}
 		tfMap[names.AttrStreamARN] = aws.ToString(table.LatestStreamArn)
 		tfMap["stream_label"] = aws.ToString(table.LatestStreamLabel)
+		// The streaming configuration for the replica table
+		// (whether streaming is enabled and the streaming view type).
+		if table.StreamSpecification != nil {
+			tfMap["stream_enabled"] = aws.ToBool(table.StreamSpecification.StreamEnabled)
+			tfMap["stream_view_type"] = string(table.StreamSpecification.StreamViewType)
+		} else {
+			tfMap["stream_enabled"] = false
+			tfMap["stream_view_type"] = ""
+		}
 
 		tfList[i] = tfMap
 	}
@@ -3971,4 +4001,42 @@ func ctyValueLegacyEquals(lhs, rhs cty.Value) bool {
 	}
 
 	return false
+}
+
+// mrscReplicaTableDrift detects MRSC replica stream drift when the consistency
+// mode is STRONG. Each replica table's actual streaming state is stored in the
+// stream_enabled and stream_view_type computed attributes in enrichReplicas,
+// and if any replica table's streaming configuration does not match the
+// global-table level configuration, a diff is enforced.
+func mrscReplicaTableDrift(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	if diff.Id() == "" {
+		return nil
+	}
+
+	oldReplicas, _ := diff.GetChange("replica")
+	replicas, ok := oldReplicas.(*schema.Set)
+	if !ok {
+		return nil
+	}
+
+	wantEnabled, _ := diff.Get("stream_enabled").(bool)
+	wantViewType, _ := diff.Get("stream_view_type").(string)
+	for _, tfMapRaw := range replicas.List() {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if v, _ := tfMap["consistency_mode"].(string); awstypes.MultiRegionConsistency(v) != awstypes.MultiRegionConsistencyStrong {
+			continue
+		}
+		gotEnabled, _ := tfMap["stream_enabled"].(bool)
+		gotViewType, _ := tfMap["stream_view_type"].(string)
+		if gotEnabled != wantEnabled || (wantEnabled && gotEnabled && gotViewType != wantViewType) {
+			if err := diff.SetNewComputed(names.AttrStreamARN); err != nil {
+				return fmt.Errorf("forcing diff for MRSC replica streaming configuration drift: %w", err)
+			}
+			break
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This PR adds the `replica.stream_enabled` and `replica.stream_view_type` computed attributes to the `aws_dynamodb_table` resource schema and starts propagating the streaming configuration to all of the replica tables specified under the `replica` set.

It also adds a new `schema.CustomizeDiffFunc` implementation that detects any drifts between the global-table's streaming configuration and the replica table streaming configurations.

We've done upgrade tests via the encapsulating Crossplane provider (from `v2.6.3` of the Crossplane provider) and the following further experiments:
```
Provisioning an MRSC global-table in a 3 replica topology with streaming enabled across all replicas using the following manifest:

apiVersion: dynamodb.aws.upbound.io/v1beta2
kind: Table
metadata:
  name: mrsc-table-streaming
spec:
  forProvider:
    region: us-east-1
    billingMode: PAY_PER_REQUEST
    hashKey: id
    attribute:
    - name: id
      type: S
    streamEnabled: true
    streamViewType: NEW_AND_OLD_IMAGES
    replica:
    - regionName: us-east-2
      consistencyMode: STRONG
    - regionName: us-west-2
      consistencyMode: STRONG

Setting spec.forProvider.streamEnabled & spec.forProvider.streamViewType should now be sufficient to configure streaming across the whole MRSC topology.

Disabling streaming after it's been enabled with something like:

kubectl patch tables.dynamodb.aws.upbound.io mrsc-table-streaming --type=merge -p='{"spec": {"forProvider":{"streamEnabled": false}}}'

Provisioning an MRSC global-table in the 3 replica topology and initially streaming not enabled:

apiVersion: dynamodb.aws.upbound.io/v1beta2
kind: Table
metadata:
  name: mrsc-table
spec:
  forProvider:
    region: us-east-1
    billingMode: PAY_PER_REQUEST
    hashKey: id
    attribute:
    - name: id
      type: S
    replica:
    - regionName: us-east-2
      consistencyMode: STRONG
    - regionName: us-west-2
      consistencyMode: STRONG

, and enabling streaming during an update with something like:

kubectl patch tables.dynamodb.aws.upbound.io mrsc-table --type=merge -p='{"spec": {"forProvider":{"streamEnabled": true, "streamViewType": "NEW_AND_OLD_IMAGES"}}}'

Provisioning an MRSC global-table in the 2-replicas-1-witness topology with streaming:

apiVersion: dynamodb.aws.upbound.io/v1beta2
kind: Table
metadata:
  name: mrsc-witness-streaming
spec:
  forProvider:
    region: us-east-1
    billingMode: PAY_PER_REQUEST
    hashKey: id
    attribute:
    - name: id
      type: S
    streamEnabled: true
    streamViewType: NEW_AND_OLD_IMAGES
    replica:
    - regionName: us-west-2
      consistencyMode: STRONG
    globalTableWitness:
      regionName: us-east-2

In the 2-replicas-1-witness topology with streaming, changing the streaming view type with something like:

kubectl patch tables.dynamodb.aws.upbound.io mrsc-witness-streaming --type=merge -p='{"spec": {"forProvider":{"streamViewType": "KEYS_ONLY"}}}'

In the 2-replicas-1-witness topology with streaming, disabling the streaming after it's been enabled.

Provisioning an MREC global table:

apiVersion: dynamodb.aws.upbound.io/v1beta2
kind: Table
metadata:
  name: mrec-table
spec:
  forProvider:
    region: us-east-1
    billingMode: PAY_PER_REQUEST
    hashKey: id
    attribute:
    - name: id
      type: S
    replica:
    - regionName: us-east-2
      consistencyMode: EVENTUAL
    - regionName: us-west-2
      consistencyMode: EVENTUAL

Trying to disable streaming/change view type fail as expected in EC mode.
```

In addition to the above scenarios, we've also successfully validated that a streaming enabled MRSC global table reconciled by the `v2.6.3` of the Crossplane provider successfully propagates streaming configuration after an upgrade to a provider with the proposed changes. The image used in these upgrade tests is:
```
xpkg.upbound.io/upbound/provider-aws-dynamodb:v2.7.0-af6db280e2d6
```